### PR TITLE
Fix chat application bugs

### DIFF
--- a/ENTERPRISE_DEPLOYMENT.md
+++ b/ENTERPRISE_DEPLOYMENT.md
@@ -130,7 +130,7 @@ The user has two options:
 1. The user can deploy the solution to an Azure Web App. In the `deployment` folder, the user can the `deployment.sh` bash script to deploy the web app.
 
 
-## Azure Arquitecture Review:
+## Azure Architecture Review:
 
 This repository contains the Bicep code to deploy an Azure App Services baseline architecture with zonal redundancy and the Azure Open Ai resource deployed in the four regions that are currently (**as of Jan 2024**) supported to run the GPT -4 Vision model.
 

--- a/ui/chainlit.md
+++ b/ui/chainlit.md
@@ -7,7 +7,7 @@ This document outlines the primary commands and options available in the testing
 | **cmd index**         | Type `cmd index` to change the name of the AI Search index.                                     |
 | **cmd password**      | Type `cmd password` to change the PDF password (if PDFs are password-protected).                |
 | **cmd tag_limit**     | Type `cmd tag_limit` to change the upper limits of the generated tags per query for the search.   |
-| **cmd topN**          | Type `cmd topN` to change how many top N results to fetch while executing the search.   |
+| **cmd top_n**          | Type `cmd top_n` to change how many top N results to fetch while executing the search.   |
 | **cmd pdf_mode**      | Type `cmd pdf_mode` to change the PDF extraction mode. Allowed values are 'gpt-4-vision' or 'document-intelligence'.   |
 | **cmd docx_mode**     | Type `cmd docx_mode` to change the docx extraction mode. Allowed values are 'document-intelligence' or 'py-docx'.   |
 | **cmd threads**       | Type `cmd threads` to change the number of threads. Allows for multi-threading during ingestion. Make sure that AZURE_OPENAI_RESOURCE_x and AZURE_OPENAI_KEY_x are properly configured in your .env file.     |

--- a/ui/chat.py
+++ b/ui/chat.py
@@ -332,7 +332,7 @@ async def main(message: cl.Message):
         elif cmd == 'pdf_mode':
             res = await cl.AskUserMessage(content="What is the PDF extraction mode?", timeout=1000).send()
             if res:
-                pdf_extraction_mode = res['output'].strip().upper()
+                pdf_extraction_mode = res['output'].strip().lower()
                 if pdf_extraction_mode in ['gpt-4-vision', 'document-intelligence']:
                     pdf_extraction_modes[cl.user_session.get("id")] = pdf_extraction_mode
                     await update_task_list()

--- a/ui/chat.py
+++ b/ui/chat.py
@@ -363,7 +363,7 @@ async def main(message: cl.Message):
                 except:
                     pass
 
-        elif cmd == 'topN': 
+        elif cmd == 'top_n': 
             res = await cl.AskUserMessage(content="What is the Top N for the Search Results?", timeout=1000).send()
             if res:
                 log_message(res)

--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -5,3 +5,4 @@ pyperclip
 colorlog
 chainlit==1.0.502
 streamlit>=1.31.1
+pydantic==2.10.1


### PR DESCRIPTION
Fix chainlit pydantic dependency error, chainlit pdf mode parsing, enterprise deployment documentation update

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Chainlit chat app with v1.0.502 doesn't start locally, and the container replica crashes at start.
* Pins the Pydantic dependency to 2.10.1 as required by this Chainlit version so the app can start.
* Trying to change the pdf mode in the chat app with the command and value GPT-4-VISION or gpt-4-vision does not work.
* Update pdf mode parser in the chat app so that it converts the command and values to lowercase.
* Fix bug parsing topN command.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run using the one-click deploy feature.
* Test the app by running Chainlit locally.
* Try to change the pdf mode in the chat application by typing GPT-4-VISION or gpt-4-vision.
* Try to change the number of search results returned in the chat app.

## What to Check
Verify that the following are valid
* Chat application starts when deployed to ACA and locally.
* The pdf mode changes.
* The number of search results changes.

## Other Information
If you don't want to pin a specific Pydantic version, update the Chainlit package to a working version such as latest and remove the Pydantic dependency in requirements.txt